### PR TITLE
Add dynamically added items to observer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export default class extends Controller {
   class: string
   threshold: number
   rootMargin: string
+  isInitialized: boolean
   observer: IntersectionObserver
 
   itemTargets: HTMLElement[]
@@ -26,6 +27,7 @@ export default class extends Controller {
   }
 
   initialize (): void {
+    this.isInitialized = false
     this.intersectionObserverCallback = this.intersectionObserverCallback.bind(this)
   }
 
@@ -36,10 +38,12 @@ export default class extends Controller {
 
     this.observer = new IntersectionObserver(this.intersectionObserverCallback, this.intersectionObserverOptions)
     this.itemTargets.forEach(item => this.observer.observe(item))
+    this.isInitialized = true
   }
 
   disconnect (): void {
     this.itemTargets.forEach(item => this.observer.unobserve(item))
+    this.observer.disconnect()
   }
 
   intersectionObserverCallback (entries: IntersectionObserverEntry[], observer: IntersectionObserver): void {
@@ -55,6 +59,12 @@ export default class extends Controller {
         observer.unobserve(target)
       }
     })
+  }
+
+  itemTargetConnected() {
+    if (this.isInitialized) {
+      this.itemTargets.forEach(item => this.observer.observe(item))
+    }
   }
 
   get intersectionObserverOptions (): IntersectionObserverInit {


### PR DESCRIPTION
When adding items to page dynamically (e.g. "Load more articles", or single-page application), adds the added/replaced items to observer. Utilizes Stimulus' `targetConnected` callback

Also adds disconnect for the observer when controller gets disconnected to allow for garbage collection